### PR TITLE
Separate min filter and mipmap

### DIFF
--- a/Plugins/CtrLibrary/UI/BCH/Material/MaterailCombinerUI.cs
+++ b/Plugins/CtrLibrary/UI/BCH/Material/MaterailCombinerUI.cs
@@ -521,9 +521,11 @@ namespace CtrLibrary
             }
 
             if (nextStage != null && ImGui.Checkbox("Save To Buffer", ref ((isAlpha) ? ref alphaUpdate : ref colorUpdate)))
+            {
                 UpdateStage();
+                ImGui.SameLine();
+            }
 
-            ImGui.SameLine();
             if (isAlpha)
                 DrawScale("Alpha Scale", index, ref alphaScale, UpdateStage);
             else


### PR DESCRIPTION
Separates the min filter and mipmap options into two drop down boxes, which are more intuitive than having both options combined into one.