### PR TITLE
Add Plugins copying to "BuildLinux.sh"

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -2,4 +2,8 @@
 
 cd "CTR Studio"
 dotnet build --runtime linux-x64 --self-contained
+
+cd "bin/Debug/net6.0"
+cp -R -T "Plugins/net6.0" "linux-x64/Plugins"
+
 read -p "Press any key to continue..."


### PR DESCRIPTION
I noticed that the generated build of CTR-Studio through the current `BuildLinux.sh` could not open any files. Seems like the issue was that the folder "Plugins" was not copied into the directory.