### PR TITLE
Fix csproj to work properly outside of Windows

### DIFF
--- a/CTR Studio/CTR Studio.csproj
+++ b/CTR Studio/CTR Studio.csproj
@@ -183,8 +183,13 @@
     <Folder Include="LUTs\" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <Exec Command="xcopy ..\Plugins\CtrLibrary\bin\$(Configuration)\net6.0 bin\$(Configuration)\net6.0\Plugins\net6.0\ /E" />
+  </Target>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$([MSBuild]::IsOSUnixLike())">
+    <Exec Command="mkdir -p ./bin/$(Configuration)/net6.0/Plugins/net6.0" />
+    <Exec Command="cp -rT ../Plugins/CtrLibrary/bin/$(Configuration)/net6.0 ./bin/$(Configuration)/net6.0/Plugins/net6.0" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Adding xcopy inside of the csproj broke the build for systems other than Windows. This adds a condition so that it will only be executed when building on Windows. Additionally, a version for Unix systems was added (effectively making BuildLinux.sh deprecated)